### PR TITLE
Relax setuptools build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ publish = [
 
 [build-system]
 requires = [
-    "setuptools~=67.6"
+    "setuptools>=67.6"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
With the same context and for the same reason as https://github.com/reity/fountains/pull/1 and https://github.com/nthparty/fe25519/pull/1.